### PR TITLE
SSCS-5293 - Integrate with bulk printing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,8 +105,8 @@ functional.shouldRunAfter(test)
 
 sonarqube {
   properties {
-    property "sonar.exclusions", 
-      "src/main/java/uk/gov/hmcts/reform/sscs/config/**," + 
+    property "sonar.exclusions",
+      "src/main/java/uk/gov/hmcts/reform/sscs/config/**," +
       "src/main/java/uk/gov/hmcts/reform/sscs/servicebus/messaging/**,"
     property "sonar.projectName", "Reform :: sscs-evidence-share"
     property "sonar.projectKey", "uk.gov.hmcts.reform:sscs-evidence-share"
@@ -153,7 +153,7 @@ repositories {
 // enforces it's own (older) version which is not recommended.
 def versions = [
   junit: '5.3.2',
-  reformLogging: '4.0.1',
+  reformLogging: '3.0.1',
   springBoot: springBoot.class.package.implementationVersion,
   springfoxSwagger: '2.9.2'
 ]
@@ -175,6 +175,7 @@ dependencies {
 
   apt "org.projectlombok:lombok:1.18.6"
 
+  compile group: 'uk.gov.hmcts.reform', name: 'send-letter-client', version: '2.1.1'
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.144'
 
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/BulkPrintServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/BulkPrintServiceTest.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import junitparams.JUnitParamsRunner;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import uk.gov.hmcts.reform.sscs.ccd.client.CcdClient;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+@SpringBootTest
+public class BulkPrintServiceTest {
+
+    // Below rules are needed to use the junitParamsRunner together with SpringRunner
+    @ClassRule
+    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
+
+    @Rule
+    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+    //end of rules needed for junitParamsRunner
+
+    private static final SscsCaseData SSCS_CASE_DATA = SscsCaseData.builder()
+        .ccdCaseId("234")
+        .appeal(Appeal.builder().appellant(
+            Appellant.builder()
+                .name(Name.builder().firstName("Appellant").lastName("LastName").build())
+                .address(Address.builder().line1("line1").build())
+                .build())
+            .build())
+        .build();
+
+
+    @MockBean
+    @SuppressWarnings({"PMD.UnusedPrivateField"})
+    private CcdClient ccdClient;
+
+    @Autowired
+    private BulkPrintService bulkPrintService;
+
+    @Test
+    @Ignore("need to get send-letter-service working locally")
+    public void willSendFileToBulkPrint() {
+        assertNotNull("bulkPrintService must be autowired", bulkPrintService);
+
+        Optional<UUID> uuidOptional = bulkPrintService.sendToBulkPrint("my data", SSCS_CASE_DATA);
+        assertTrue(uuidOptional.isPresent());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/Application.java
@@ -3,9 +3,21 @@ package uk.gov.hmcts.reform.sscs;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.retry.annotation.EnableRetry;
+import uk.gov.hmcts.reform.authorisation.healthcheck.ServiceAuthHealthIndicator;
+import uk.gov.hmcts.reform.sendletter.SendLetterAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(
+    scanBasePackages = {"uk.gov.hmcts.reform.sscs"},
+    exclude = {ServiceAuthHealthIndicator.class, SendLetterAutoConfiguration.class})
 @EnableCircuitBreaker
+@EnableFeignClients(basePackages =
+    {
+        "uk.gov.hmcts.reform.sendletter",
+        "uk.gov.hmcts.reform.sscs.idam"
+    })
+@EnableRetry
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class Application {
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/ServiceTokenGeneratorConfiguration.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.sscs.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
+
+@Configuration
+@Lazy
+@EnableFeignClients(basePackageClasses = ServiceAuthorisationApi.class)
+public class ServiceTokenGeneratorConfiguration {
+
+    @Bean
+    public AuthTokenGenerator authTokenGenerator(
+        @Value("${idam.s2s-auth.totp_secret}") final String secret,
+        @Value("${idam.s2s-auth.microservice}") final String microService,
+        final ServiceAuthorisationApi serviceAuthorisationApi
+    ) {
+        return AuthTokenGeneratorFactory.createDefaultGenerator(secret, microService, serviceAuthorisationApi);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/exception/BulkPrintException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/exception/BulkPrintException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.sscs.exception;
+
+public class BulkPrintException extends RuntimeException {
+    public BulkPrintException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/BulkPrintService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/BulkPrintService.java
@@ -1,0 +1,83 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sendletter.api.LetterWithPdfsRequest;
+import uk.gov.hmcts.reform.sendletter.api.SendLetterApi;
+import uk.gov.hmcts.reform.sendletter.api.SendLetterResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.exception.BulkPrintException;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static java.util.Base64.getEncoder;
+import static java.util.Collections.singletonList;
+
+@Service
+@Slf4j
+public class BulkPrintService {
+
+    private static final String XEROX_TYPE_PARAMETER = "DIV001";
+    private static final String CCD_ID = "ccdId";
+    private static final String LETTER_TYPE_KEY = "letterType";
+    private static final String APPELLANT_NAME = "appellantName";
+
+    private final SendLetterApi sendLetterApi;
+    private final IdamService idamService;
+    private final boolean sendLetterEnabled;
+
+    @Autowired
+    public BulkPrintService(SendLetterApi sendLetterApi, IdamService idamService,
+                            @Value("${send-letter.enabled}") boolean sendLetterEnabled) {
+        this.idamService = idamService;
+        this.sendLetterApi = sendLetterApi;
+        this.sendLetterEnabled = sendLetterEnabled;
+    }
+
+    public Optional<UUID> sendToBulkPrint(final String dataToPrint, final SscsCaseData sscsCaseData)
+        throws BulkPrintException {
+        if (sendLetterEnabled) {
+            String encodedData = getEncoder().encodeToString(dataToPrint.getBytes());
+            final String authToken = idamService.generateServiceAuthorization();
+            return sendLetter(authToken, encodedData, sscsCaseData);
+        }
+        return Optional.empty();
+
+    }
+
+    private Optional<UUID> sendLetter(String authToken, String encodedData, SscsCaseData sscsCaseData) {
+        try {
+            SendLetterResponse sendLetterResponse = sendLetterApi.sendLetter(
+                authToken,
+                new LetterWithPdfsRequest(
+                    singletonList(encodedData),
+                    XEROX_TYPE_PARAMETER,
+                    getAdditionalData(sscsCaseData)
+                )
+            );
+            log.info("Letter service produced the following letter Id {} for case {}",
+                sendLetterResponse.letterId, sscsCaseData.getCcdCaseId());
+
+            return Optional.of(sendLetterResponse.letterId);
+        } catch (Exception e) {
+            String message = format("Failed to send to bulk print for case %s", sscsCaseData.getCcdCaseId());
+            log.error(message, e);
+            throw new BulkPrintException(message, e);
+        }
+    }
+
+    private static Map<String, Object> getAdditionalData(final SscsCaseData sscsCaseData) {
+        Map<String, Object> additionalData = new HashMap<>();
+        additionalData.put(LETTER_TYPE_KEY, "sscs-data-pack");
+        additionalData.put(CCD_ID, sscsCaseData.getCcdCaseId());
+        additionalData.put(APPELLANT_NAME, sscsCaseData.getAppeal().getAppellant().getName().getFullNameNoTitle());
+        return additionalData;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,25 @@ spring:
   application:
     name: sscs evidence share
 
+send-letter:
+  url: ${SEND_LETTER_SERIVCE_BASEURL:http://localhost:4021}
+  enabled: ${SEND_LETTER_SERIVCE_ENABLED:true}
+
+idam:
+  url: ${IDAM_URL:http://localhost:4501}
+  s2s-auth:
+    totp_secret: ${IDAM.S2S-AUTH.TOTP_SECRET:AAAAAAAAAAAAAAAC}
+    microservice: ${IDAM.S2S-AUTH.MICROSERVICE:sscs}
+    url: ${IDAM.S2S-AUTH:http://localhost:4502}
+  oauth2:
+    user:
+      email: ${IDAM_SSCS_SYSTEMUPDATE_USER:SSCS_SYSTEM_UPDATE}
+      password: ${IDAM_SSCS_SYSTEMUPDATE_PASSWORD:SSCS_SYSTEM_UPDATE}
+    client:
+      id: ${IDAM_OAUTH2_CLIENT_ID:sscs}
+      secret: ${IDAM_OAUTH2_CLIENT_SECRET:QM5RQQ53LZFOSIXJ}
+    redirectUrl: ${IDAM_OAUTH2_REDIRECT_URL:https://localhost:9000/poc}
+
 amqp:
   host: ${AMQP_HOST:localhost}
   username: ${AMQP_USERNAME:guest}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/BulkPrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/BulkPrintServiceTest.java
@@ -1,0 +1,83 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sendletter.api.LetterWithPdfsRequest;
+import uk.gov.hmcts.reform.sendletter.api.SendLetterApi;
+import uk.gov.hmcts.reform.sendletter.api.SendLetterResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.exception.BulkPrintException;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BulkPrintServiceTest {
+
+    private static final String DATA = "myData";
+    private static final UUID LETTER_ID = UUID.randomUUID();
+
+    private static final SscsCaseData SSCS_CASE_DATA = SscsCaseData.builder()
+        .ccdCaseId("234")
+        .appeal(Appeal.builder().appellant(
+            Appellant.builder()
+                .name(Name.builder().firstName("Appellant").lastName("LastName").build())
+                .address(Address.builder().line1("line1").build())
+                .build())
+            .build())
+        .build();
+    private static final String AUTH_TOKEN = "Auth_Token";
+
+    private BulkPrintService bulkPrintService;
+    @Mock
+    private SendLetterApi sendLetterApi;
+    @Mock
+    private IdamService idamService;
+
+    @Before
+    public void setUp() {
+        this.bulkPrintService = new BulkPrintService(sendLetterApi, idamService, true);
+        when(idamService.generateServiceAuthorization()).thenReturn(AUTH_TOKEN);
+
+    }
+
+    @Test
+    public void willSendToBulkPrint() {
+        when(sendLetterApi.sendLetter(eq(AUTH_TOKEN), any(LetterWithPdfsRequest.class)))
+            .thenReturn(new SendLetterResponse(LETTER_ID));
+        Optional<UUID> letterIdOptional = bulkPrintService.sendToBulkPrint(DATA, SSCS_CASE_DATA);
+        assertEquals("letterIds must be equal", Optional.of(LETTER_ID), letterIdOptional);
+    }
+
+    @Test(expected = BulkPrintException.class)
+    public void willThrowAnyExceptionsToBulkPrint() {
+        when(sendLetterApi.sendLetter(eq(AUTH_TOKEN), any(LetterWithPdfsRequest.class)))
+            .thenThrow(new RuntimeException("error"));
+        bulkPrintService.sendToBulkPrint(DATA, SSCS_CASE_DATA);
+    }
+
+
+    @Test
+    public void sendLetterNotEnabledWillNotSendToBulkPrint() {
+        BulkPrintService notEnabledBulkPrint = new BulkPrintService(sendLetterApi, idamService, false);
+        notEnabledBulkPrint.sendToBulkPrint(DATA, SSCS_CASE_DATA);
+        verifyZeroInteractions(idamService);
+        verifyZeroInteractions(sendLetterApi);
+    }
+
+
+}


### PR DESCRIPTION

Jira: https://tools.hmcts.net/jira/browse/SSCS-5293

Added code to integrate with bulk printing.
Ignored the integration tests as we cannot run the service locally or in docker.

Have not hooked up the code to the evidence share service as we don't have the document to print as yet.

As we need to authenticate to the send-file service - I had to downgrade the hmcts logging library to the one used in sscs-common.

The values sent to the SendLetterApi are dummy data and need to be agreed once we have integrated and on-boarded with them. 
