### PR TITLE
SSCS-5257-Springburn DRT address updated

### DIFF
--- a/src/main/resources/dwpAddresses.json
+++ b/src/main/resources/dwpAddresses.json
@@ -154,15 +154,10 @@
     {
       "code": "Springburn DRT",
       "address": {
-      }
-    },
-    {
-      "code": "Watford DRT",
-      "address": {
-        "line1": "Watford Service Centre",
+        "line1": "Springburn DRT",
         "line2": "Post Handling Site B",
         "line3": "WOLVERHAMPTON",
-        "postCode": "WV99 1RH"
+        "postCode": "WV99 1AB"
       }
     },
     {


### PR DESCRIPTION
Springburn DRT address updated

Dwp address data should be as in https://tools.hmcts.net/jira/browse/SSCS-5257

MRN Location Name | Address | RPC Address | Excela Address
-- | -- | -- | --
Springburn DRT | Springburn DRT Post Handling Site B WOLVERHAMPTON WV99 1AB | Use existing lookup functionality; the address should map to Appellant / Appointee's postcode | PO BOX XXX Exela BSP Services Harlow CM19 5QS
-- | -- | -- | --


