### PR TITLE
SSCS-5416 - Use Parameter "SSC001" in send letter service

### DIFF
--- a/kubernetes/deployment.template.yaml
+++ b/kubernetes/deployment.template.yaml
@@ -52,9 +52,9 @@ spec:
             - name: TRUST_ALL_CERTS
               value: "true"
             - name: SUBSCRIPTION_NAME
-              value: "evidenceshare-subscription"
+              value: "sscs-evidenceshare-subscription-aat"
             - name: TOPIC_NAME
-              value: "evidenceshare-topic"
+              value: "sscs-evidenceshare-topic-aat"
             - name: AMQP_HOST
               value: "sscs-servicebus-aat.servicebus.windows.net"
             - name: AMQP_USERNAME

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/BulkPrintService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/BulkPrintService.java
@@ -20,7 +20,7 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 @Slf4j
 public class BulkPrintService {
 
-    private static final String XEROX_TYPE_PARAMETER = "DIV001";
+    private static final String XEROX_TYPE_PARAMETER = "SSC001";
     private static final String CCD_ID = "ccdId";
     private static final String LETTER_TYPE_KEY = "letterType";
     private static final String APPELLANT_NAME = "appellantName";
@@ -63,7 +63,8 @@ public class BulkPrintService {
 
             return Optional.of(sendLetterResponse.letterId);
         } catch (Exception e) {
-            String message = format("Failed to send to bulk print for case %s", sscsCaseData.getCcdCaseId());
+            String message = format("Failed to send to bulk print for case %s with error %s.",
+                sscsCaseData.getCcdCaseId(), e.getMessage());
             log.error(message, e);
             throw new BulkPrintException(message, e);
         }


### PR DESCRIPTION
When copying the code from a divorce project, a divorce project specific parameter was copied.
We need to change it to an SSCS specific property. This being `SSC001`.