### PR TITLE
SSCS-5560 - Track and handle unrecoverable evidence share errors (MVP)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,13 @@ def versions = [
   lombok: '1.18.6'
 ]
 
+// solves CVE-2019-12086
+// remove once spring manager incorporates this changes
+dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9') {
+  entry 'jackson-core'
+  entry 'jackson-databind'
+}
+
 dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -179,13 +179,6 @@ def versions = [
   lombok: '1.18.6'
 ]
 
-// solves CVE-2019-12086
-// remove once spring manager incorporates this changes
-dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9') {
-  entry 'jackson-core'
-  entry 'jackson-databind'
-}
-
 dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
@@ -239,6 +232,13 @@ dependencyManagement {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'
+    }
+
+    // solves CVE-2019-12086
+    // remove once spring manager incorporates this changes
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9') {
+      entry 'jackson-core'
+      entry 'jackson-databind'
     }
   }
 }

--- a/charts/sscs-evidence-share/values.yaml
+++ b/charts/sscs-evidence-share/values.yaml
@@ -40,3 +40,4 @@ java:
     TOPIC_NAME: "sscs-evidenceshare-topic-demo"
     AMQP_HOST: "sscs-servicebus-aat.servicebus.windows.net"
     AMQP_USERNAME: "SendAndListenSharedAccessKey"
+    MAX_RETRY_ATTEMPTS: 3

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/EvidenceShareServiceIt.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/EvidenceShareServiceIt.java
@@ -36,7 +36,7 @@ import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.Pdf;
 import uk.gov.hmcts.reform.sscs.document.EvidenceDownloadClientApi;
 import uk.gov.hmcts.reform.sscs.document.EvidenceMetadataDownloadClientApi;
-import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
+import uk.gov.hmcts.reform.sscs.exception.NoMrnDetailsException;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 
@@ -168,7 +168,7 @@ public class EvidenceShareServiceIt {
         verify(ccdService).updateCase(any(), any(), eq(EventType.SENT_TO_DWP.getCcdType()), any(), eq("Case has been sent to the DWP"), any());
     }
 
-    @Test(expected = DwpAddressLookupException.class)
+    @Test(expected = NoMrnDetailsException.class)
     public void appealWithNoMrnDate_shouldNotGenerateTemplateOrAddToCcd() throws IOException {
         assertNotNull("evidenceShareService must be autowired", evidenceShareService);
         String path = Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
@@ -177,7 +177,7 @@ public class EvidenceShareServiceIt {
 
         try {
             evidenceShareService.processMessage(json);
-        } catch (DwpAddressLookupException e) {
+        } catch (NoMrnDetailsException e) {
             verifyNoMoreInteractions(restTemplate);
             verifyNoMoreInteractions(evidenceManagementService);
             verifyNoMoreInteractions(ccdService);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/EvidenceShareServiceIt.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/EvidenceShareServiceIt.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.Pdf;
 import uk.gov.hmcts.reform.sscs.document.EvidenceDownloadClientApi;
 import uk.gov.hmcts.reform.sscs.document.EvidenceMetadataDownloadClientApi;
+import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 
@@ -167,20 +168,21 @@ public class EvidenceShareServiceIt {
         verify(ccdService).updateCase(any(), any(), eq(EventType.SENT_TO_DWP.getCcdType()), any(), eq("Case has been sent to the DWP"), any());
     }
 
-    @Test
+    @Test(expected = DwpAddressLookupException.class)
     public void appealWithNoMrnDate_shouldNotGenerateTemplateOrAddToCcd() throws IOException {
         assertNotNull("evidenceShareService must be autowired", evidenceShareService);
         String path = Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
             .getResource("appealReceivedCallback.json")).getFile();
         String json = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());
 
-        Optional<UUID> optionalUuid = evidenceShareService.processMessage(json);
-
-        assertEquals(Optional.empty(), optionalUuid);
-
-        verifyNoMoreInteractions(restTemplate);
-        verifyNoMoreInteractions(evidenceManagementService);
-        verifyNoMoreInteractions(ccdService);
+        try {
+            evidenceShareService.processMessage(json);
+        } catch (DwpAddressLookupException e) {
+            verifyNoMoreInteractions(restTemplate);
+            verifyNoMoreInteractions(evidenceManagementService);
+            verifyNoMoreInteractions(ccdService);
+            throw e;
+        }
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/sscs/exception/DwpAddressLookupException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/exception/DwpAddressLookupException.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.sscs.exception;
+
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class DwpAddressLookupException extends RuntimeException {
+    public static final long serialVersionUID = -7268250396297541580L;
+
+    public DwpAddressLookupException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/exception/NoMrnDetailsException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/exception/NoMrnDetailsException.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.sscs.exception;
+
+import static java.lang.String.format;
+
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class NoMrnDetailsException extends RuntimeException {
+    public static final long serialVersionUID = -3863598202357106145L;
+
+    public NoMrnDetailsException(SscsCaseData caseData) {
+        super(format("There is no Appeal Mrn details, for caseId %s.", caseData.getCcdCaseId()));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/exception/PdfStoreException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/exception/PdfStoreException.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.sscs.exception;
+
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class PdfStoreException extends RuntimeException {
+    public static final long serialVersionUID = -7268250396297541580L;
+
+    public PdfStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/DocumentManagementServiceWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/DocumentManagementServiceWrapper.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.docmosis.domain.DocumentHolder;
+import uk.gov.hmcts.reform.sscs.docmosis.service.DocumentManagementService;
+import uk.gov.hmcts.reform.sscs.exception.PdfGenerationException;
+import uk.gov.hmcts.reform.sscs.exception.PdfStoreException;
+
+@Slf4j
+@Service
+public class DocumentManagementServiceWrapper {
+
+    private final DocumentManagementService documentManagementService;
+    private Integer maxRetryAttempts;
+
+    @Autowired
+    public DocumentManagementServiceWrapper(DocumentManagementService documentManagementService,
+                                            @Value("${send-letter.maxRetryAttempts}") Integer maxRetryAttempts) {
+        this.documentManagementService = documentManagementService;
+        this.maxRetryAttempts = maxRetryAttempts;
+    }
+
+    public void generateDocumentAndAddToCcd(DocumentHolder holder, SscsCaseData caseData) {
+        generateDocumentAndAddToCcdWithRetry(holder, caseData, 1);
+    }
+
+    private void generateDocumentAndAddToCcdWithRetry(DocumentHolder holder, SscsCaseData caseData,
+                                                      Integer reTryNumber) {
+        try {
+            documentManagementService.generateDocumentAndAddToCcd(holder, caseData);
+        } catch (PdfGenerationException e) {
+            throw new PdfStoreException(e.getMessage(), e);
+        } catch (Exception e) {
+            if (reTryNumber > maxRetryAttempts) {
+                throw new PdfStoreException(e.getMessage(), e);
+            }
+            generateDocumentAndAddToCcdWithRetry(holder, caseData, reTryNumber + 1);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/DocumentPlaceholderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/DocumentPlaceholderService.java
@@ -4,10 +4,11 @@ import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.sscs.config.PlaceholderConstants.*;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.docmosis.config.PdfDocumentConfig;
 import uk.gov.hmcts.reform.sscs.domain.DwpAddress;
+import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
 
 @Service
 @Slf4j
@@ -27,14 +29,14 @@ public class DocumentPlaceholderService {
     private PdfDocumentConfig pdfDocumentConfig;
 
     public Map<String, Object> generatePlaceholders(SscsCaseData caseData, LocalDateTime caseCreatedDate) {
-        Map<String, Object> placeholders = new HashMap<>();
+        Map<String, Object> placeholders = new ConcurrentHashMap<>();
 
         Appeal appeal = caseData.getAppeal();
         placeholders.put(CASE_CREATED_DATE_LITERAL, caseCreatedDate.toLocalDate().toString());
         placeholders.put(BENEFIT_TYPE_LITERAL, appeal.getBenefitType().getDescription().toUpperCase());
         placeholders.put(APPELLANT_FULL_NAME_LITERAL, appeal.getAppellant().getName().getAbbreviatedFullName());
         placeholders.put(CASE_ID_LITERAL, caseData.getCcdCaseId());
-        placeholders.put(NINO_LITERAL, appeal.getAppellant().getIdentity().getNino());
+        placeholders.put(NINO_LITERAL, defaultToEmptyStringIfNull(appeal.getAppellant().getIdentity().getNino()));
         placeholders.put(SSCS_URL_LITERAL, SSCS_URL);
         placeholders.put(GENERATED_DATE_LITERAL, generateNowDate());
         placeholders.put(pdfDocumentConfig.getHmctsImgKey(), pdfDocumentConfig.getHmctsImgVal());
@@ -57,14 +59,14 @@ public class DocumentPlaceholderService {
         }
         //FIXME: somehow add to some exception queue when null - this should be covered by another ticket
         if (rpc != null) {
-            placeholders.put(REGIONAL_OFFICE_ADDRESS_LINE1_LITERAL, rpc.getAddress1());
-            placeholders.put(REGIONAL_OFFICE_ADDRESS_LINE2_LITERAL, rpc.getAddress2());
-            placeholders.put(REGIONAL_OFFICE_ADDRESS_LINE3_LITERAL, rpc.getAddress3());
-            placeholders.put(REGIONAL_OFFICE_ADDRESS_LINE4_LITERAL, rpc.getAddress4());
-            placeholders.put(REGIONAL_OFFICE_COUNTY_LITERAL, rpc.getCity());
-            placeholders.put(REGIONAL_OFFICE_PHONE_LITERAL, rpc.getPhoneNumber());
-            placeholders.put(REGIONAL_OFFICE_FAX_LITERAL, rpc.getFaxNumber());
-            placeholders.put(REGIONAL_OFFICE_POSTCODE_LITERAL, rpc.getPostcode());
+            placeholders.put(REGIONAL_OFFICE_ADDRESS_LINE1_LITERAL, defaultToEmptyStringIfNull(rpc.getAddress1()));
+            placeholders.put(REGIONAL_OFFICE_ADDRESS_LINE2_LITERAL, defaultToEmptyStringIfNull(rpc.getAddress2()));
+            placeholders.put(REGIONAL_OFFICE_ADDRESS_LINE3_LITERAL, defaultToEmptyStringIfNull(rpc.getAddress3()));
+            placeholders.put(REGIONAL_OFFICE_ADDRESS_LINE4_LITERAL, defaultToEmptyStringIfNull(rpc.getAddress4()));
+            placeholders.put(REGIONAL_OFFICE_COUNTY_LITERAL, defaultToEmptyStringIfNull(rpc.getCity()));
+            placeholders.put(REGIONAL_OFFICE_PHONE_LITERAL, defaultToEmptyStringIfNull(rpc.getPhoneNumber()));
+            placeholders.put(REGIONAL_OFFICE_FAX_LITERAL, defaultToEmptyStringIfNull(rpc.getFaxNumber()));
+            placeholders.put(REGIONAL_OFFICE_POSTCODE_LITERAL, defaultToEmptyStringIfNull(rpc.getPostcode()));
         }
     }
 
@@ -73,33 +75,39 @@ public class DocumentPlaceholderService {
             && nonNull(caseData.getAppeal().getMrnDetails())
             && nonNull(caseData.getAppeal().getMrnDetails().getDwpIssuingOffice())) {
 
-            final Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(
+            final DwpAddress dwpAddress = dwpAddressLookup.lookup(
                 caseData.getAppeal().getBenefitType().getCode(),
                 caseData.getAppeal().getMrnDetails().getDwpIssuingOffice());
 
-            optionalAddress.ifPresent(dwpAddress -> setDwpAddress(placeholders, dwpAddress));
+            setDwpAddress(placeholders, dwpAddress);
+        } else {
+            throw new DwpAddressLookupException("There is no Appeal Mrn details.");
         }
     }
 
     private void setDwpAddress(Map<String, Object> placeholders, DwpAddress dwpAddress) {
         String[] lines = dwpAddress.lines();
         if (lines.length >= 1) {
-            placeholders.put(DWP_ADDRESS_LINE1_LITERAL, lines[0]);
+            placeholders.put(DWP_ADDRESS_LINE1_LITERAL, defaultToEmptyStringIfNull(lines[0]));
         }
         if (lines.length >= 2) {
-            placeholders.put(DWP_ADDRESS_LINE2_LITERAL, lines[1]);
+            placeholders.put(DWP_ADDRESS_LINE2_LITERAL, defaultToEmptyStringIfNull(lines[1]));
         }
         if (lines.length >= 3) {
-            placeholders.put(DWP_ADDRESS_LINE3_LITERAL, lines[2]);
+            placeholders.put(DWP_ADDRESS_LINE3_LITERAL, defaultToEmptyStringIfNull(lines[2]));
         }
         if (lines.length >= 4) {
-            placeholders.put(DWP_ADDRESS_LINE4_LITERAL, lines[3]);
+            placeholders.put(DWP_ADDRESS_LINE4_LITERAL, defaultToEmptyStringIfNull(lines[3]));
         }
     }
 
     private static boolean hasRegionalProcessingCenter(SscsCaseData ccdResponse) {
         return nonNull(ccdResponse.getRegionalProcessingCenter())
             && nonNull(ccdResponse.getRegionalProcessingCenter().getName());
+    }
+
+    private Object defaultToEmptyStringIfNull(Object value) {
+        return (value == null) ? StringUtils.EMPTY : value;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/DocumentPlaceholderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/DocumentPlaceholderService.java
@@ -16,7 +16,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.docmosis.config.PdfDocumentConfig;
 import uk.gov.hmcts.reform.sscs.domain.DwpAddress;
-import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
+import uk.gov.hmcts.reform.sscs.exception.NoMrnDetailsException;
 
 @Service
 @Slf4j
@@ -81,7 +81,7 @@ public class DocumentPlaceholderService {
 
             setDwpAddress(placeholders, dwpAddress);
         } else {
-            throw new DwpAddressLookupException("There is no Appeal Mrn details.");
+            throw new NoMrnDetailsException(caseData);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/DwpAddressLookup.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/DwpAddressLookup.java
@@ -14,6 +14,7 @@ import org.json.simple.parser.JSONParser;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.domain.BenefitLookup;
 import uk.gov.hmcts.reform.sscs.domain.DwpAddress;
+import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
 
 @Service
 @Slf4j
@@ -46,15 +47,16 @@ public class DwpAddressLookup {
     private static final JSONObject EXCELA_CONFIG = (JSONObject) configObject.get(EXCELA);
     public static final DwpAddress EXCELA_DWP_ADDRESS = BenefitLookup.getAddress((JSONObject) EXCELA_CONFIG.get(ADDRESS));
 
-    public Optional<DwpAddress> lookup(String benefitType, String dwpIssuingOffice) {
+    public DwpAddress lookup(String benefitType, String dwpIssuingOffice) {
         log.info("looking up address for benefitType {} and dwpIssuingOffice {}", benefitType, dwpIssuingOffice);
         Optional<DwpAddress> dwpAddressOptional =
             getDwpAddress(StringUtils.stripToNull(benefitType), StringUtils.stripToNull(dwpIssuingOffice));
         if (!dwpAddressOptional.isPresent()) {
-            log.warn("could not find dwp address for benefitType {} and dwpIssuingOffice {}",
-                benefitType, dwpIssuingOffice);
+            throw new DwpAddressLookupException(String.format("could not find dwp address for benefitType %s and dwpIssuingOffice %s",
+                benefitType, dwpIssuingOffice));
+
         }
-        return dwpAddressOptional;
+        return dwpAddressOptional.get();
     }
 
     private Optional<DwpAddress> getDwpAddress(String benefitType, String dwpIssuingOffice) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/EvidenceShareService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/EvidenceShareService.java
@@ -21,7 +21,6 @@ import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.config.EvidenceShareConfig;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.DocumentHolder;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.Pdf;
-import uk.gov.hmcts.reform.sscs.docmosis.service.DocumentManagementService;
 import uk.gov.hmcts.reform.sscs.factory.DocumentRequestFactory;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 
@@ -33,7 +32,7 @@ public class EvidenceShareService {
 
     private final SscsCaseCallbackDeserializer sscsCaseCallbackDeserializer;
 
-    private final DocumentManagementService documentManagementService;
+    private final DocumentManagementServiceWrapper documentManagementServiceWrapper;
 
     private final DocumentRequestFactory documentRequestFactory;
 
@@ -50,7 +49,7 @@ public class EvidenceShareService {
     @Autowired
     public EvidenceShareService(
         SscsCaseCallbackDeserializer sscsDeserializer,
-        DocumentManagementService documentManagementService,
+        DocumentManagementServiceWrapper documentManagementServiceWrapper,
         DocumentRequestFactory documentRequestFactory,
         EvidenceManagementService evidenceManagementService,
         BulkPrintService bulkPrintService,
@@ -60,7 +59,7 @@ public class EvidenceShareService {
     ) {
 
         this.sscsCaseCallbackDeserializer = sscsDeserializer;
-        this.documentManagementService = documentManagementService;
+        this.documentManagementServiceWrapper = documentManagementServiceWrapper;
         this.documentRequestFactory = documentRequestFactory;
         this.evidenceManagementService = evidenceManagementService;
         this.bulkPrintService = bulkPrintService;
@@ -86,7 +85,7 @@ public class EvidenceShareService {
             if (holder.getTemplate() != null) {
                 log.info("Generating document for case id {}", sscsCaseDataCallback.getCaseDetails().getId());
 
-                documentManagementService.generateDocumentAndAddToCcd(holder, caseData);
+                documentManagementServiceWrapper.generateDocumentAndAddToCcd(holder, caseData);
                 List<Pdf> existingCasePdfs = toPdf(caseData.getSscsDocument());
 
                 Optional<UUID> uuid = bulkPrintService.sendToBulkPrint(existingCasePdfs, caseData);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/TemplateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/TemplateService.java
@@ -11,9 +11,9 @@ import uk.gov.hmcts.reform.sscs.docmosis.domain.Template;
 @Slf4j
 public class TemplateService {
 
-    private String dl6TemplateName;
+    private final String dl6TemplateName;
 
-    private String dl16TemplateName;
+    private final String dl16TemplateName;
 
     public TemplateService(@Value("${docmosis.template.dl6.templateName}") String dl6TemplateName,
                            @Value("${docmosis.template.dl16.templateName}") String dl16TemplateName) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumer.java
@@ -1,8 +1,9 @@
 package uk.gov.hmcts.reform.sscs.servicebus;
 
+import static java.lang.String.format;
+
 import java.util.Optional;
 import java.util.UUID;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.jms.annotation.JmsListener;
@@ -30,12 +31,20 @@ public class TopicConsumer {
     )
     public void onMessage(String message) {
         try {
+            processMessage(message);
+        } catch (Exception e) {
+            log.error(format("Caught error %s", e.getMessage()), e);
+        }
+
+    }
+
+    private void processMessage(String message) {
+        try {
             Optional<UUID> optionalUuid = evidenceShareService.processMessage(message);
             log.info("Processed message for with returned value {}", optionalUuid);
         } catch (PdfStoreException | BulkPrintException | DwpAddressLookupException exception) {
             // unrecoverable. Catch to remove it from the queue.
-            log.error(exception.getMessage(), exception);
+            log.error(format("Caught unrecoverable error: %s", exception.getMessage()), exception);
         }
-
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumer.java
@@ -10,6 +10,7 @@ import org.springframework.jms.annotation.JmsListener;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.exception.BulkPrintException;
 import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
+import uk.gov.hmcts.reform.sscs.exception.NoMrnDetailsException;
 import uk.gov.hmcts.reform.sscs.exception.PdfStoreException;
 import uk.gov.hmcts.reform.sscs.service.EvidenceShareService;
 
@@ -33,7 +34,7 @@ public class TopicConsumer {
         try {
             processMessage(message);
         } catch (Exception e) {
-            log.error(format("Caught error %s", e.getMessage()), e);
+            log.error(format("Caught unknown unrecoverable error %s", e.getMessage()), e);
         }
 
     }
@@ -42,7 +43,7 @@ public class TopicConsumer {
         try {
             Optional<UUID> optionalUuid = evidenceShareService.processMessage(message);
             log.info("Processed message for with returned value {}", optionalUuid);
-        } catch (PdfStoreException | BulkPrintException | DwpAddressLookupException exception) {
+        } catch (PdfStoreException | BulkPrintException | DwpAddressLookupException | NoMrnDetailsException exception) {
             // unrecoverable. Catch to remove it from the queue.
             log.error(format("Caught unrecoverable error: %s", exception.getMessage()), exception);
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,6 +49,7 @@ document_management.url: ${DOCUMENT_MANAGEMENT_URL:http://dm-store:4506}
 send-letter:
   url: ${SEND_LETTER_SERVICE_BASEURL:http://localhost:4021}
   enabled: ${SEND_LETTER_SERVICE_ENABLED:false}
+  maxRetryAttempts: ${MAX_RETRY_ATTEMPTS:3}
 
 idam:
   url: ${IDAM_API_URL:http://localhost:4501}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/BulkPrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/BulkPrintServiceTest.java
@@ -48,9 +48,8 @@ public class BulkPrintServiceTest {
 
     @Before
     public void setUp() {
-        this.bulkPrintService = new BulkPrintService(sendLetterApi, idamService, true);
+        this.bulkPrintService = new BulkPrintService(sendLetterApi, idamService, true, 1);
         when(idamService.generateServiceAuthorization()).thenReturn(AUTH_TOKEN);
-
     }
 
     @Test
@@ -71,7 +70,7 @@ public class BulkPrintServiceTest {
 
     @Test
     public void sendLetterNotEnabledWillNotSendToBulkPrint() {
-        BulkPrintService notEnabledBulkPrint = new BulkPrintService(sendLetterApi, idamService, false);
+        BulkPrintService notEnabledBulkPrint = new BulkPrintService(sendLetterApi, idamService, false, 1);
         notEnabledBulkPrint.sendToBulkPrint(PDF_LIST, SSCS_CASE_DATA);
         verifyZeroInteractions(idamService);
         verifyZeroInteractions(sendLetterApi);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/DocumentManagementServiceWrapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/DocumentManagementServiceWrapperTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.docmosis.domain.DocumentHolder;
+import uk.gov.hmcts.reform.sscs.docmosis.domain.Pdf;
+import uk.gov.hmcts.reform.sscs.docmosis.service.DocumentManagementService;
+import uk.gov.hmcts.reform.sscs.exception.PdfGenerationException;
+import uk.gov.hmcts.reform.sscs.exception.PdfStoreException;
+
+
+public class DocumentManagementServiceWrapperTest {
+
+    private final DocumentManagementService documentManagementService = mock(DocumentManagementService.class);
+    private final Pdf pdf = mock(Pdf.class);
+
+    private final DocumentManagementServiceWrapper service =
+        new DocumentManagementServiceWrapper(documentManagementService, 3);
+    private final DocumentHolder holder = DocumentHolder.builder().build();
+    private final SscsCaseData caseData = SscsCaseData.builder().build();
+
+    @Test
+    public void successfulCallToDocumentManagementService_willBeCalledOnce() {
+        when(documentManagementService.generateDocumentAndAddToCcd(any(), any())).thenReturn(pdf);
+
+        service.generateDocumentAndAddToCcd(holder, caseData);
+
+        verify(documentManagementService).generateDocumentAndAddToCcd(eq(holder), eq(caseData));
+        verifyNoMoreInteractions(documentManagementService);
+    }
+
+    @Test(expected = PdfStoreException.class)
+    public void ifAPdfGenerationExceptionIsThrownServiceCallWillNotBeRetried() {
+        when(documentManagementService.generateDocumentAndAddToCcd(any(), any()))
+            .thenThrow(new PdfGenerationException("a message", new RuntimeException("blah")));
+        try {
+            service.generateDocumentAndAddToCcd(holder, caseData);
+        } catch (PdfStoreException e) {
+            verify(documentManagementService).generateDocumentAndAddToCcd(eq(holder), eq(caseData));
+            verifyNoMoreInteractions(documentManagementService);
+            throw e;
+        }
+    }
+
+    @Test
+    public void anExceptionWillBeCaughtAndRetriedUntilSuccessful() {
+        when(documentManagementService.generateDocumentAndAddToCcd(any(), any()))
+            .thenThrow(new RuntimeException("blah"))
+            .thenThrow(new RuntimeException("blah"))
+            .thenReturn(pdf);
+
+        service.generateDocumentAndAddToCcd(holder, caseData);
+
+        verify(documentManagementService, times(3)).generateDocumentAndAddToCcd(eq(holder), eq(caseData));
+        verifyNoMoreInteractions(documentManagementService);
+    }
+
+    @Test(expected = PdfStoreException.class)
+    public void anExceptionWillBeCaughtAndRetriedUntilItFails() {
+        when(documentManagementService.generateDocumentAndAddToCcd(any(), any()))
+            .thenThrow(new RuntimeException("blah"))
+            .thenThrow(new RuntimeException("blah"))
+            .thenThrow(new RuntimeException("blah"));
+
+        service.generateDocumentAndAddToCcd(holder, caseData);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/DocumentPlaceholderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/DocumentPlaceholderServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.docmosis.config.PdfDocumentConfig;
 import uk.gov.hmcts.reform.sscs.domain.DwpAddress;
-import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
+import uk.gov.hmcts.reform.sscs.exception.NoMrnDetailsException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DocumentPlaceholderServiceTest {
@@ -147,14 +147,14 @@ public class DocumentPlaceholderServiceTest {
         assertNull(result.get(DWP_ADDRESS_LINE4_LITERAL));
     }
 
-    @Test(expected = DwpAddressLookupException.class)
+    @Test(expected = NoMrnDetailsException.class)
     public void asAppealWithNoMrnDetailsWillNotHaveADwpAddress() {
         buildCaseData(null);
         caseData = caseData.toBuilder().appeal(caseData.getAppeal().toBuilder().mrnDetails(null).build()).build();
         service.generatePlaceholders(caseData, now);
     }
 
-    @Test(expected = DwpAddressLookupException.class)
+    @Test(expected = NoMrnDetailsException.class)
     public void anAppealWithNoDwpIssuingOfficeWillNotHaveADwpAddress() {
         buildCaseData(null);
         caseData = caseData.toBuilder().appeal(caseData.getAppeal().toBuilder().mrnDetails(

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/DocumentPlaceholderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/DocumentPlaceholderServiceTest.java
@@ -2,13 +2,11 @@ package uk.gov.hmcts.reform.sscs.service;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.config.PlaceholderConstants.*;
 
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Optional;
 
 import org.joda.time.DateTimeUtils;
 import org.junit.Before;
@@ -20,6 +18,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.docmosis.config.PdfDocumentConfig;
 import uk.gov.hmcts.reform.sscs.domain.DwpAddress;
+import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DocumentPlaceholderServiceTest {
@@ -46,6 +45,8 @@ public class DocumentPlaceholderServiceTest {
     @Before
     public void setup() {
         DateTimeUtils.setCurrentMillisFixed(1550000000000L);
+        when(pdfDocumentConfig.getHmctsImgKey()).thenReturn("HmctsImgKey");
+        when(pdfDocumentConfig.getHmctsImgVal()).thenReturn("HmctsImgVal");
         now = LocalDateTime.now();
     }
 
@@ -58,7 +59,7 @@ public class DocumentPlaceholderServiceTest {
 
         buildCaseData(rpc);
         DwpAddress dwpAddress = new DwpAddress(RPC_ADDRESS1, RPC_ADDRESS2, RPC_CITY, POSTCODE);
-        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(Optional.of(dwpAddress));
+        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(dwpAddress);
 
         Map<String, Object> result = service.generatePlaceholders(caseData, now);
 
@@ -85,7 +86,7 @@ public class DocumentPlaceholderServiceTest {
     public void givenACaseDataWithNoRpc_thenGenerateThePlaceholderMappingsWithoutRpc() {
         buildCaseData(null);
         when(dwpAddressLookup.lookup("PIP", "1"))
-            .thenReturn(Optional.of(new DwpAddress(RPC_ADDRESS1, RPC_ADDRESS2, RPC_CITY, POSTCODE)));
+            .thenReturn(new DwpAddress(RPC_ADDRESS1, RPC_ADDRESS2, RPC_CITY, POSTCODE));
 
         Map<String, Object> result = service.generatePlaceholders(caseData, now);
 
@@ -102,7 +103,7 @@ public class DocumentPlaceholderServiceTest {
     public void anAddressWithTwoLinesAndPostCodeWillNotHaveRow4() {
         buildCaseData(null);
         DwpAddress dwpAddress = new DwpAddress(RPC_ADDRESS1, RPC_ADDRESS2, POSTCODE);
-        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(Optional.of(dwpAddress));
+        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(dwpAddress);
         Map<String, Object> result = service.generatePlaceholders(caseData, now);
         assertEquals(dwpAddress.lines()[0], result.get(DWP_ADDRESS_LINE1_LITERAL));
         assertEquals(dwpAddress.lines()[1], result.get(DWP_ADDRESS_LINE2_LITERAL));
@@ -114,7 +115,7 @@ public class DocumentPlaceholderServiceTest {
     public void anAddressWithOneLineAndPostCodeWillNotHaveRow3AndRow4() {
         buildCaseData(null);
         DwpAddress dwpAddress = new DwpAddress(RPC_ADDRESS1, "", POSTCODE);
-        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(Optional.of(dwpAddress));
+        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(dwpAddress);
         Map<String, Object> result = service.generatePlaceholders(caseData, now);
         assertEquals(dwpAddress.lines()[0], result.get(DWP_ADDRESS_LINE1_LITERAL));
         assertEquals(dwpAddress.lines()[1], result.get(DWP_ADDRESS_LINE2_LITERAL));
@@ -126,7 +127,7 @@ public class DocumentPlaceholderServiceTest {
     public void addressWithOneLineWillNotHaveRow2AndRow3AndRow4() {
         buildCaseData(null);
         DwpAddress dwpAddress = new DwpAddress("", "", POSTCODE);
-        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(Optional.of(dwpAddress));
+        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(dwpAddress);
         Map<String, Object> result = service.generatePlaceholders(caseData, now);
         assertEquals(dwpAddress.lines()[0], result.get(DWP_ADDRESS_LINE1_LITERAL));
         assertNull(result.get(DWP_ADDRESS_LINE2_LITERAL));
@@ -138,7 +139,7 @@ public class DocumentPlaceholderServiceTest {
     public void addressWithNoLinesWillNotHaveADwpAddress() {
         buildCaseData(null);
         DwpAddress dwpAddress = new DwpAddress("", "", "");
-        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(Optional.of(dwpAddress));
+        when(dwpAddressLookup.lookup("PIP", "1")).thenReturn(dwpAddress);
         Map<String, Object> result = service.generatePlaceholders(caseData, now);
         assertNull(result.get(DWP_ADDRESS_LINE1_LITERAL));
         assertNull(result.get(DWP_ADDRESS_LINE2_LITERAL));
@@ -146,29 +147,19 @@ public class DocumentPlaceholderServiceTest {
         assertNull(result.get(DWP_ADDRESS_LINE4_LITERAL));
     }
 
-    @Test
+    @Test(expected = DwpAddressLookupException.class)
     public void asAppealWithNoMrnDetailsWillNotHaveADwpAddress() {
         buildCaseData(null);
         caseData = caseData.toBuilder().appeal(caseData.getAppeal().toBuilder().mrnDetails(null).build()).build();
-        Map<String, Object> result = service.generatePlaceholders(caseData, now);
-        verifyZeroInteractions(dwpAddressLookup);
-        assertNull(result.get(DWP_ADDRESS_LINE1_LITERAL));
-        assertNull(result.get(DWP_ADDRESS_LINE2_LITERAL));
-        assertNull(result.get(DWP_ADDRESS_LINE3_LITERAL));
-        assertNull(result.get(DWP_ADDRESS_LINE4_LITERAL));
+        service.generatePlaceholders(caseData, now);
     }
 
-    @Test
+    @Test(expected = DwpAddressLookupException.class)
     public void anAppealWithNoDwpIssuingOfficeWillNotHaveADwpAddress() {
         buildCaseData(null);
         caseData = caseData.toBuilder().appeal(caseData.getAppeal().toBuilder().mrnDetails(
             MrnDetails.builder().mrnLateReason("soz").build()).build()).build();
-        Map<String, Object> result = service.generatePlaceholders(caseData, now);
-        verifyZeroInteractions(dwpAddressLookup);
-        assertNull(result.get(DWP_ADDRESS_LINE1_LITERAL));
-        assertNull(result.get(DWP_ADDRESS_LINE2_LITERAL));
-        assertNull(result.get(DWP_ADDRESS_LINE3_LITERAL));
-        assertNull(result.get(DWP_ADDRESS_LINE4_LITERAL));
+        service.generatePlaceholders(caseData, now);
     }
 
     private void buildCaseData(RegionalProcessingCenter rpc) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/DwpAddressLookupTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/DwpAddressLookupTest.java
@@ -2,13 +2,12 @@ package uk.gov.hmcts.reform.sscs.service;
 
 import static org.junit.Assert.*;
 
-import java.util.Optional;
-
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.hmcts.reform.sscs.domain.DwpAddress;
+import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
 
 @RunWith(JUnitParamsRunner.class)
 public class DwpAddressLookupTest {
@@ -21,8 +20,8 @@ public class DwpAddressLookupTest {
     @Test
     @Parameters({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"})
     public void pipAddressesExist(final String dwpIssuingOffice) {
-        Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(PIP, dwpIssuingOffice);
-        assertTrue(optionalAddress.isPresent());
+        DwpAddress address = dwpAddressLookup.lookup(PIP, dwpIssuingOffice);
+        assertNotNull(address);
     }
 
     @Test
@@ -31,8 +30,8 @@ public class DwpAddressLookupTest {
         "ESA, Balham DRT", "EsA, Balham DRT", "esa, Balham DRT"
     })
     public void benefitTypeIsCaseInsensitive(final String benefitType, String dwpIssuingOffice) {
-        Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(benefitType, dwpIssuingOffice);
-        assertTrue(optionalAddress.isPresent());
+        DwpAddress address = dwpAddressLookup.lookup(benefitType, dwpIssuingOffice);
+        assertNotNull(address);
     }
 
     @Test
@@ -42,29 +41,26 @@ public class DwpAddressLookupTest {
         "Norwich DRT", "Sheffield DRT"
     })
     public void esaAddressesExist(final String dwpIssuingOffice) {
-        Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(ESA, dwpIssuingOffice);
-        assertTrue(optionalAddress.isPresent());
+        DwpAddress address = dwpAddressLookup.lookup(ESA, dwpIssuingOffice);
+        assertNotNull(address);
     }
 
-    @Test
+    @Test(expected = DwpAddressLookupException.class)
     @Parameters({"JOB", "UNK", "PLOP", "BIG", "FIG"})
     public void unknownBenefitTypeReturnsNone(final String benefitType) {
-        Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(benefitType, "1");
-        assertFalse(optionalAddress.isPresent());
+        dwpAddressLookup.lookup(benefitType, "1");
     }
 
-    @Test
+    @Test(expected = DwpAddressLookupException.class)
     @Parameters({"11", "12", "13", "14", "JOB"})
     public void unknownPipDwpIssuingOfficeReturnsNone(final String dwpIssuingOffice) {
-        Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(PIP, dwpIssuingOffice);
-        assertFalse(optionalAddress.isPresent());
+        dwpAddressLookup.lookup(PIP, dwpIssuingOffice);
     }
 
-    @Test
+    @Test(expected = DwpAddressLookupException.class)
     @Parameters({"JOB", "UNK", "PLOP", "BIG", "11"})
     public void unknownEsaDwpIssuingOfficeReturnsNone(final String dwpIssuingOffice) {
-        Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(ESA, dwpIssuingOffice);
-        assertFalse(optionalAddress.isPresent());
+        dwpAddressLookup.lookup(ESA, dwpIssuingOffice);
     }
 
     @Test
@@ -76,18 +72,16 @@ public class DwpAddressLookupTest {
 
     @Test
     public void pip_1_isConfiguredCorrectly() {
-        Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(PIP, "1");
-        assertTrue(optionalAddress.isPresent());
-        DwpAddress address = optionalAddress.get();
+        DwpAddress address = dwpAddressLookup.lookup(PIP, "1");
+        assertNotNull(address);
         assertArrayEquals(new String[]{"Mail Handling Site A", "WOLVERHAMPTON", "WV98 1AA"}, address.lines());
     }
 
     @Test
     @Parameters({"PIP", "ESA", "JOB", "UNK", "PLOP", "BIG", "11"})
     public void willAlwaysReturnTestAddressForATestDwpIssuingOffice(final String benefitType) {
-        Optional<DwpAddress> optionalAddress = dwpAddressLookup.lookup(benefitType, "test-hmcts-address");
-        assertTrue(optionalAddress.isPresent());
-        DwpAddress address = optionalAddress.get();
+        DwpAddress address = dwpAddressLookup.lookup(benefitType, "test-hmcts-address");
+        assertNotNull(address);
         assertEquals("E1 8FA", address.lines()[3]);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/EvidenceShareServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/EvidenceShareServiceTest.java
@@ -26,7 +26,6 @@ import uk.gov.hmcts.reform.sscs.config.EvidenceShareConfig;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.DocumentHolder;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.Pdf;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.Template;
-import uk.gov.hmcts.reform.sscs.docmosis.service.DocumentManagementService;
 import uk.gov.hmcts.reform.sscs.factory.DocumentRequestFactory;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 
@@ -42,7 +41,7 @@ public class EvidenceShareServiceTest {
     private SscsCaseCallbackDeserializer sscsCaseCallbackDeserializer;
 
     @Mock
-    private DocumentManagementService documentManagementService;
+    private DocumentManagementServiceWrapper documentManagementServiceWrapper;
 
     @Mock
     private DocumentRequestFactory documentRequestFactory;
@@ -68,7 +67,7 @@ public class EvidenceShareServiceTest {
 
     @Before
     public void setUp() {
-        evidenceShareService = new EvidenceShareService(sscsCaseCallbackDeserializer, documentManagementService, documentRequestFactory,
+        evidenceShareService = new EvidenceShareService(sscsCaseCallbackDeserializer, documentManagementServiceWrapper, documentRequestFactory,
             evidenceManagementService, bulkPrintService, evidenceShareConfig, ccdCaseService, idamService);
         when(evidenceShareConfig.getSubmitTypes()).thenReturn(Collections.singletonList("paper"));
     }
@@ -134,7 +133,7 @@ public class EvidenceShareServiceTest {
         DocumentHolder holder = DocumentHolder.builder().placeholders(placeholders).template(null).build();
 
         when(documentRequestFactory.create(caseDetails.getCaseData(), now)).thenReturn(holder);
-        verifyNoMoreInteractions(documentManagementService);
+        verifyNoMoreInteractions(documentManagementServiceWrapper);
 
         Optional<UUID> optionalUuid = evidenceShareService.processMessage(MY_JSON_DATA);
 
@@ -171,7 +170,7 @@ public class EvidenceShareServiceTest {
 
         Optional<UUID> optionalUuid = evidenceShareService.processMessage(MY_JSON_DATA);
 
-        verifyNoMoreInteractions(documentManagementService);
+        verifyNoMoreInteractions(documentManagementServiceWrapper);
         assertEquals(Optional.empty(), optionalUuid);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumerTest.java
@@ -5,10 +5,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
-import uk.gov.hmcts.reform.sscs.exception.BulkPrintException;
-import uk.gov.hmcts.reform.sscs.exception.ClientAuthorisationException;
-import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
-import uk.gov.hmcts.reform.sscs.exception.PdfStoreException;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.exception.*;
 import uk.gov.hmcts.reform.sscs.service.EvidenceShareService;
 
 public class TopicConsumerTest {
@@ -37,6 +35,13 @@ public class TopicConsumerTest {
     @Test
     public void dwpAddressLookupExceptionWillBeCaught() {
         DwpAddressLookupException exception = new DwpAddressLookupException(MESSAGE);
+        when(evidenceShareService.processMessage(any())).thenThrow(exception);
+        topicConsumer.onMessage(MESSAGE);
+    }
+
+    @Test
+    public void noMrnDetailsExceptionWillBeCaught() {
+        NoMrnDetailsException exception = new NoMrnDetailsException(SscsCaseData.builder().ccdCaseId("123").build());
         when(evidenceShareService.processMessage(any())).thenThrow(exception);
         topicConsumer.onMessage(MESSAGE);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumerTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.sscs.servicebus;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.exception.BulkPrintException;
+import uk.gov.hmcts.reform.sscs.exception.ClientAuthorisationException;
+import uk.gov.hmcts.reform.sscs.exception.DwpAddressLookupException;
+import uk.gov.hmcts.reform.sscs.exception.PdfStoreException;
+import uk.gov.hmcts.reform.sscs.service.EvidenceShareService;
+
+public class TopicConsumerTest {
+
+    private static final String MESSAGE = "message";
+    private static final Exception EXCEPTION = new RuntimeException("blah");
+
+    private final EvidenceShareService evidenceShareService = mock(EvidenceShareService.class);
+
+    private final TopicConsumer topicConsumer = new TopicConsumer(evidenceShareService);
+
+    @Test
+    public void bulkPrintExceptionWillBeCaught() {
+        BulkPrintException exception = new BulkPrintException(MESSAGE, EXCEPTION);
+        when(evidenceShareService.processMessage(any())).thenThrow(exception);
+        topicConsumer.onMessage(MESSAGE);
+    }
+
+    @Test
+    public void pdfStoreExceptionWillBeCaught() {
+        PdfStoreException exception = new PdfStoreException(MESSAGE, EXCEPTION);
+        when(evidenceShareService.processMessage(any())).thenThrow(exception);
+        topicConsumer.onMessage(MESSAGE);
+    }
+
+    @Test
+    public void dwpAddressLookupExceptionWillBeCaught() {
+        DwpAddressLookupException exception = new DwpAddressLookupException(MESSAGE);
+        when(evidenceShareService.processMessage(any())).thenThrow(exception);
+        topicConsumer.onMessage(MESSAGE);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullPointerExceptionWillNotBeCaught() {
+        NullPointerException exception = new NullPointerException();
+        when(evidenceShareService.processMessage(any())).thenThrow(exception);
+        topicConsumer.onMessage(MESSAGE);
+    }
+
+    @Test(expected = ClientAuthorisationException.class)
+    public void clientAuthorisationExceptionWillNotBeCaught() {
+        ClientAuthorisationException exception = new ClientAuthorisationException(EXCEPTION);
+        when(evidenceShareService.processMessage(any())).thenThrow(exception);
+        topicConsumer.onMessage(MESSAGE);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumerTest.java
@@ -41,15 +41,15 @@ public class TopicConsumerTest {
         topicConsumer.onMessage(MESSAGE);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void nullPointerExceptionWillNotBeCaught() {
+    @Test
+    public void nullPointerExceptionWillBeCaught() {
         NullPointerException exception = new NullPointerException();
         when(evidenceShareService.processMessage(any())).thenThrow(exception);
         topicConsumer.onMessage(MESSAGE);
     }
 
-    @Test(expected = ClientAuthorisationException.class)
-    public void clientAuthorisationExceptionWillNotBeCaught() {
+    @Test
+    public void clientAuthorisationExceptionWillBeCaught() {
         ClientAuthorisationException exception = new ClientAuthorisationException(EXCEPTION);
         when(evidenceShareService.processMessage(any())).thenThrow(exception);
         topicConsumer.onMessage(MESSAGE);


### PR DESCRIPTION
As HMCTS, I want to ensure that any errors that occur during bulk print are detected and handled in a way that allows the case to progress.

The approach for dealing with errors is as follows:

If successful, take off JMS message queue
If unrecoverable error then trigger an alert and take off queue. These should be picked up by Support. Examples of unrecoverable errors are:

- Can't match postcode in the AirLookupRC
- More than 30 documents in list for bulk print (limit of 30)
- Any error from Docmosis when composing DL6/16

**Important Update** 
For this ticket, treat all errors as unrecoverable