### PR TITLE
SSCS-7796 - Create new digital flag in the Robotics JSON

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/robotics/json/RoboticsJsonMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/robotics/json/RoboticsJsonMapper.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.json.simple.JSONArray;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,7 +76,12 @@ public class RoboticsJsonMapper {
         if (roboticsWrapper.getState().equals(State.READY_TO_LIST)) {
             isReadyToList = "Yes";
         }
+        String isDigital = "No";
+        if (StringUtils.equals(roboticsWrapper.getSscsCaseData().getCreatedInGapsFrom(), ("readyToList"))) {
+            isDigital = "Yes";
+        }
         obj.put("isReadyToList", isReadyToList);
+        obj.put("isDigital", isDigital);
 
         obj.put("dwpResponseDate", sscsCaseData.getDwpResponseDate());
 

--- a/src/main/resources/schema/sscs-robotics.json
+++ b/src/main/resources/schema/sscs-robotics.json
@@ -26,6 +26,7 @@
     "representative": {"$ref": "#/definitions/person"},
     "rpcEmail": {"type": "string"},
     "isReadyToList": {"$ref": "#/definitions/yesOrNo"},
+    "isDigital": {"$ref": "#/definitions/yesOrNo"},
     "dwpResponseDate": {"$ref": "#/definitions/dateType"},
     "dwpIssuingOffice": {"type": "string"},
     "dwpPresentingOffice": {"type": "string"},

--- a/src/test/java/uk/gov/hmcts/reform/sscs/robotics/json/RoboticsJsonMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/robotics/json/RoboticsJsonMapperTest.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.sscs.robotics.json;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
 
 import java.time.LocalDate;
@@ -16,9 +18,12 @@ import junitparams.Parameters;
 import junitparams.converters.Nullable;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.model.AirlookupBenefitToVenue;
 import uk.gov.hmcts.reform.sscs.robotics.domain.RoboticsWrapper;
@@ -29,6 +34,8 @@ import uk.gov.hmcts.reform.sscs.service.RegionalProcessingCenterService;
 @RunWith(JUnitParamsRunner.class)
 public class RoboticsJsonMapperTest {
 
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
     private RoboticsJsonMapper roboticsJsonMapper;
     private RoboticsWrapper roboticsWrapper;
     private RoboticsJsonValidator roboticsJsonValidator = new RoboticsJsonValidator(
@@ -45,7 +52,6 @@ public class RoboticsJsonMapperTest {
 
     @Before
     public void setup() {
-        initMocks(this);
         roboticsJsonMapper = new RoboticsJsonMapper(dwpAddressLookupService, regionalProcessingCenterService, airLookupService);
 
         SscsCaseData sscsCaseData = buildCaseData();
@@ -71,7 +77,7 @@ public class RoboticsJsonMapperTest {
         roboticsJsonValidator.validate(roboticsJson);
 
         assertEquals(
-            "If this fails, add an assertion below, do not just increment the number :)", 23,
+            "If this fails, add an assertion below, do not just increment the number :)", 24,
             roboticsJson.length()
         );
 
@@ -500,6 +506,16 @@ public class RoboticsJsonMapperTest {
         assertEquals("DWP PIP (1)", roboticsJson.get("dwpPresentingOffice"));
         assertEquals("No", roboticsJson.get("dwpIsOfficerAttending"));
         assertEquals("No", roboticsJson.get("dwpUcb"));
+    }
+
+    @Test
+    @Parameters({"validAppeal, No", "readyToList, Yes", "null, No"})
+    public void givenCreatedInGapsFrom_shouldSetRetrieveIsDigitalAccordingly(@Nullable String createdInGapsFrom, String expectedIsDigital) {
+        roboticsWrapper.getSscsCaseData().setCreatedInGapsFrom(createdInGapsFrom);
+
+        roboticsJson = roboticsJsonMapper.map(roboticsWrapper);
+
+        assertThat(roboticsJson.get("isDigital"), is(expectedIsDigital));
     }
 
 }


### PR DESCRIPTION
SSCS-7796 - Create new digital flag in the Robotics JSON

We want to introduce a new key of “isDigital” in the robotics JSON where the following logic applies:

If the “createdInGapsFrom” value is “readyToList” then populate “isDigital” key with “Yes”
If the “createdInGapsFrom” value is anything else (not “readyToList”) then populate the “isDigital” key with “No”