### PR TITLE
Fix the build on master

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -55,7 +55,7 @@ withPipeline(type, product, component) {
   }
 
   before('functionalTest:aat') {
-    withAksClient('nonprod') {
+    withAksClient('nonprod', product) {
       // Vars needed for AKS testing
       env.DOCUMENT_MANAGEMENT_URL = 'http://dm-store-aat.service.core-compute-aat.internal'
     }


### PR DESCRIPTION
# Fix the build

currently on the master build we are seeing this error.

```
Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object 
(uk.gov.hmcts.contino.AppPipelineDsl withAksClient java.lang.String org.jenkinsci.plugins.workflow.cps.CpsClosure2). 
Administrators can decide whether to approve or reject this signature.
```