### PR TITLE
SSCS-8482 Remove extra call to update office

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,8 @@ configurations.all {
   resolutionStrategy {
     eachDependency { DependencyResolveDetails details ->
       if (details.requested.group == 'org.codehaus.groovy') {
-        details.useVersion "3.0.2"
+        // CVE-2020-17521
+        details.useVersion "3.0.7"
         details.because "needed by rest-assured>=4.3"
       }
     }
@@ -316,13 +317,6 @@ dependencyManagement {
         entry 'cxf-rt-rs-client'
         entry 'cxf-rt-security'
         entry 'cxf-rt-transports-http'
-    }
-
-    // CVE-2020-17521
-    dependencySet(group: 'org.codehaus.groovy', version: '3.0.7') {
-      entry 'groovy'
-      entry 'groovy-json'
-      entry 'groovy-xml'
     }
 
   }

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'send-letter-client', version: '3.0.2'
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.2'
 
-  compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '4.1.15'
+  compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '4.1.22'
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.4.17'
 
   //Remove when our dependencies pull in this version or later

--- a/build.gradle
+++ b/build.gradle
@@ -318,6 +318,13 @@ dependencyManagement {
         entry 'cxf-rt-transports-http'
     }
 
+    // CVE-2020-17521
+    dependencySet(group: 'org.codehaus.groovy', version: '3.0.7') {
+      entry 'groovy'
+      entry 'groovy-json'
+      entry 'groovy-xml'
+    }
+
   }
 }
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AbstractFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AbstractFunctionalTest.java
@@ -58,15 +58,15 @@ public abstract class AbstractFunctionalTest {
     private final String localInstance = "http://localhost:8091";
 
     void createNonDigitalCaseWithEvent(EventType eventType) {
-        createCaseWithValidAppealState(eventType, "PIP", "Personal Independence Payment", State.VALID_APPEAL.getId());
+        createCaseWithState(eventType, "PIP", "Personal Independence Payment", State.VALID_APPEAL.getId());
     }
 
     void createDigitalCaseWithEvent(EventType eventType) {
-        createCaseWithValidAppealState(eventType, "PIP", "Personal Independence Payment", State.READY_TO_LIST.getId());
+        createCaseWithState(eventType, "PIP", "Personal Independence Payment", State.READY_TO_LIST.getId());
     }
 
 
-    void createCaseWithValidAppealState(EventType eventType, String benefitType, String benefitDescription, String createdInGapsFrom) {
+    SscsCaseDetails createCaseWithState(EventType eventType, String benefitType, String benefitDescription, String createdInGapsFrom) {
         idamTokens = idamService.getIdamTokens();
 
         SscsCaseData minimalCaseData = CaseDataUtils.buildMinimalCaseData();
@@ -84,9 +84,18 @@ public abstract class AbstractFunctionalTest {
 
 
         SscsCaseDetails caseDetails = ccdService.createCase(caseData, eventType.getCcdType(),
-            "Evidence share service send to DWP test",
-            "Evidence share service send to DWP case created", idamTokens);
+            "Evidence share service created case",
+            "Evidence share service case created for functional test", idamTokens);
         ccdCaseId = String.valueOf(caseDetails.getId());
+        return caseDetails;
+    }
+
+    void updateCaseEvent(EventType eventType, SscsCaseDetails caseDetails) {
+        idamTokens = idamService.getIdamTokens();
+
+        ccdService.updateCase(caseDetails.getData(), caseDetails.getId(),
+            eventType.getCcdType(), "Evidence share update case test",
+            "Evidence share service pushed case update for functional test", idamService.getIdamTokens());
     }
 
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AbstractFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AbstractFunctionalTest.java
@@ -57,8 +57,12 @@ public abstract class AbstractFunctionalTest {
     private final String tcaInstance = System.getenv("TEST_URL");
     private final String localInstance = "http://localhost:8091";
 
-    void createCaseWithValidAppealState(EventType eventType) {
+    void createNonDigitalCaseWithEvent(EventType eventType) {
         createCaseWithValidAppealState(eventType, "PIP", "Personal Independence Payment", State.VALID_APPEAL.getId());
+    }
+
+    void createDigitalCaseWithEvent(EventType eventType) {
+        createCaseWithValidAppealState(eventType, "PIP", "Personal Independence Payment", State.READY_TO_LIST.getId());
     }
 
 
@@ -96,7 +100,7 @@ public abstract class AbstractFunctionalTest {
         return FileUtils.readFileToString(new File(file), StandardCharsets.UTF_8.name());
     }
 
-    public void simulateCcdCallback(String json) throws IOException {
+    public void simulateCcdCallback(String json) {
 
         baseURI = StringUtils.isNotBlank(tcaInstance) ? tcaInstance : localInstance;
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AppealToProceedFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AppealToProceedFunctionalTest.java
@@ -6,7 +6,6 @@ import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.*;
 import java.io.IOException;
 import java.time.LocalDate;
 import org.junit.Test;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 
 public class AppealToProceedFunctionalTest extends AbstractFunctionalTest {
@@ -17,9 +16,9 @@ public class AppealToProceedFunctionalTest extends AbstractFunctionalTest {
 
     // Need tribunals running to pass this functional test
     @Test
-    public void processAnAppealToProceedEvent_shouldUpdateInterlocReviewState() throws IOException {
+    public void processAnAppealToProceedEvent_shouldUpdateHmctsDwpState() throws IOException {
 
-        createCaseWithValidAppealState(NON_COMPLIANT);
+        createDigitalCaseWithEvent(NON_COMPLIANT);
 
         String json = getJson(APPEAL_TO_PROCEED.getCcdType());
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
@@ -28,8 +27,8 @@ public class AppealToProceedFunctionalTest extends AbstractFunctionalTest {
         simulateCcdCallback(json);
 
         SscsCaseDetails caseDetails = findCaseById(ccdCaseId);
-        SscsCaseData caseData = caseDetails.getData();
 
-        assertEquals("reviewByTcw", caseData.getInterlocReviewState());
+        assertEquals("sentToDwp", caseDetails.getData().getHmctsDwpState());
+        assertEquals("withDwp", caseDetails.getState());
     }
 }

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/EvidenceShareFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/EvidenceShareFunctionalTest.java
@@ -3,11 +3,12 @@ package uk.gov.hmcts.reform.sscs.functional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.CREATE_TEST_CASE;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.VALID_APPEAL_CREATED;
 
-import io.github.artsok.RepeatedIfExceptionsTest;
 import java.time.LocalDate;
 import java.util.List;
+import org.junit.Test;
 import org.junit.jupiter.api.BeforeEach;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
@@ -25,10 +26,10 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
         ccdCaseId = null;
     }
 
-    @RepeatedIfExceptionsTest(repeats = 3, suspend = 5000L)
+    @Test
     public void processANonDigitalAppealWithValidMrn_shouldGenerateADl6AndAddToCcdAndUpdateState() throws Exception {
 
-        createNonDigitalCaseWithEvent(VALID_APPEAL_CREATED);
+        createNonDigitalCaseWithEvent(CREATE_TEST_CASE);
 
         String json = getJson(VALID_APPEAL_CREATED.getCcdType());
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
@@ -49,10 +50,10 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
         assertEquals(LocalDate.now().toString(), caseData.getDateCaseSentToGaps());
     }
 
-    @RepeatedIfExceptionsTest(repeats = 3, suspend = 5000)
+    @Test
     public void processANonDigitalAppealWithNoValidMrnDate_shouldNotBeSentToDwpAndShouldBeUpdatedToFlagError() throws Exception {
 
-        createNonDigitalCaseWithEvent(VALID_APPEAL_CREATED);
+        createNonDigitalCaseWithEvent(CREATE_TEST_CASE);
 
         String json = getJson(VALID_APPEAL_CREATED.getCcdType());
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
@@ -67,9 +68,9 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
         assertEquals("failedSending", caseDetails.getData().getHmctsDwpState());
     }
 
-    @RepeatedIfExceptionsTest(repeats = 3, suspend = 5000)
+    @Test
     public void processAnAppealWithLateMrn_shouldGenerateADl16AndAddToCcdAndUpdateState() throws Exception {
-        createNonDigitalCaseWithEvent(VALID_APPEAL_CREATED);
+        createNonDigitalCaseWithEvent(CREATE_TEST_CASE);
 
         String json = getJson(VALID_APPEAL_CREATED.getCcdType());
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
@@ -89,10 +90,10 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
         assertEquals(LocalDate.now().toString(), caseData.getDateSentToDwp());
     }
 
-    @RepeatedIfExceptionsTest(repeats = 3, suspend = 5000L)
+    @Test
     public void processADigitalAppealWithValidMrn_shouldSendToWithDwpState() throws Exception {
 
-        createDigitalCaseWithEvent(VALID_APPEAL_CREATED);
+        createDigitalCaseWithEvent(CREATE_TEST_CASE);
 
         String json = getJson(VALID_APPEAL_CREATED.getCcdType());
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/EvidenceShareFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/EvidenceShareFunctionalTest.java
@@ -46,7 +46,7 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
     }
 
     @RepeatedIfExceptionsTest(repeats = 3, suspend = 5000)
-    public void processAnAppealWithNoValidMrnDate_shouldNoTBeSentToDwpAndShouldBeUpdatedToFlagError() throws Exception {
+    public void processAnAppealWithNoValidMrnDate_shouldNotBeSentToDwpAndShouldBeUpdatedToFlagError() throws Exception {
 
         createCaseWithValidAppealState(VALID_APPEAL_CREATED);
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/IssueDirectionFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/IssueDirectionFunctionalTest.java
@@ -19,7 +19,7 @@ public class IssueDirectionFunctionalTest extends AbstractFunctionalTest {
     @Test
     public void processAnIssueDirectionEvent_shouldUpdateInterlocReviewState() throws IOException {
 
-        createCaseWithValidAppealState(NON_COMPLIANT);
+        createDigitalCaseWithEvent(NON_COMPLIANT);
 
         String json = getJson(DIRECTION_ISSUED.getCcdType());
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/IssueFurtherEvidenceHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/IssueFurtherEvidenceHandlerFunctionalTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
+import uk.gov.hmcts.reform.sscs.ccd.domain.State;
 import uk.gov.hmcts.reform.sscs.domain.pdf.ByteArrayMultipartFile;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 
@@ -67,10 +68,11 @@ public class IssueFurtherEvidenceHandlerFunctionalTest extends AbstractFunctiona
 
     private String createTestData(String fileName) throws IOException {
         String docUrl = uploadDocToDocMgmtStore();
-        createCaseWithValidAppealState(VALID_APPEAL_CREATED);
+        createDigitalCaseWithEvent(VALID_APPEAL_CREATED);
         String json = getJson(fileName);
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
         json = json.replace("EVIDENCE_DOCUMENT_URL_PLACEHOLDER", docUrl);
+        json = json.replace("CREATED_IN_GAPS_FROM", State.READY_TO_LIST.getId());
         return json.replace("EVIDENCE_DOCUMENT_BINARY_URL_PLACEHOLDER", docUrl + "/binary");
     }
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/IssueFurtherEvidenceHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/IssueFurtherEvidenceHandlerFunctionalTest.java
@@ -2,8 +2,7 @@ package uk.gov.hmcts.reform.sscs.functional;
 
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertNull;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.springframework.http.MediaType.APPLICATION_PDF;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.ISSUE_FURTHER_EVIDENCE;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.VALID_APPEAL_CREATED;
@@ -47,12 +46,12 @@ public class IssueFurtherEvidenceHandlerFunctionalTest extends AbstractFunctiona
     private void verifyEvidenceIsNotIssued() {
         SscsCaseDetails caseDetails = findCaseById(ccdCaseId);
         SscsCaseData caseData = caseDetails.getData();
-        assertThat(caseData.getHmctsDwpState(), is("failedSendingFurtherEvidence"));
+        assertEquals("failedSendingFurtherEvidence", caseData.getHmctsDwpState());
         List<SscsDocument> docs = caseData.getSscsDocument();
         assertNull(docs.get(0).getValue().getEvidenceIssued());
-        assertThat(docs.get(1).getValue().getEvidenceIssued(), is("No"));
-        assertThat(docs.get(2).getValue().getEvidenceIssued(), is("No"));
-        assertThat(docs.get(3).getValue().getEvidenceIssued(), is("No"));
+        assertEquals("No", docs.get(1).getValue().getEvidenceIssued());
+        assertEquals("No", docs.get(2).getValue().getEvidenceIssued());
+        assertEquals("No", docs.get(3).getValue().getEvidenceIssued());
     }
 
     private void verifyEvidenceIssued() {
@@ -61,9 +60,9 @@ public class IssueFurtherEvidenceHandlerFunctionalTest extends AbstractFunctiona
         List<SscsDocument> docs = caseData.getSscsDocument();
 
         assertNull(docs.get(0).getValue().getEvidenceIssued());
-        assertThat(docs.get(1).getValue().getEvidenceIssued(), is("Yes"));
-        assertThat(docs.get(2).getValue().getEvidenceIssued(), is("Yes"));
-        assertThat(docs.get(3).getValue().getEvidenceIssued(), is("Yes"));
+        assertEquals("Yes", docs.get(1).getValue().getEvidenceIssued());
+        assertEquals("Yes", docs.get(2).getValue().getEvidenceIssued());
+        assertEquals("Yes", docs.get(3).getValue().getEvidenceIssued());
     }
 
     private String createTestData(String fileName) throws IOException {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
+import uk.gov.hmcts.reform.sscs.ccd.domain.State;
 import uk.gov.hmcts.reform.sscs.domain.pdf.ByteArrayMultipartFile;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 
@@ -49,10 +50,11 @@ public class ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest exten
 
     private String createTestData() throws IOException {
         String docUrl = uploadDocToDocMgmtStore();
-        createCaseWithValidAppealState(VALID_APPEAL_CREATED);
+        createDigitalCaseWithEvent(VALID_APPEAL_CREATED);
         String json = getJson(REISSUE_FURTHER_EVIDENCE.getCcdType());
         json = json.replaceAll("CASE_ID_TO_BE_REPLACED", ccdCaseId);
         json = json.replaceAll("EVIDENCE_DOCUMENT_URL_PLACEHOLDER", docUrl);
+        json = json.replace("CREATED_IN_GAPS_FROM", State.READY_TO_LIST.getId());
         return json.replaceAll("EVIDENCE_DOCUMENT_BINARY_URL_PLACEHOLDER", docUrl + "/binary");
     }
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest.java
@@ -2,8 +2,7 @@ package uk.gov.hmcts.reform.sscs.functional;
 
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertNull;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.springframework.http.MediaType.APPLICATION_PDF;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.REISSUE_FURTHER_EVIDENCE;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.VALID_APPEAL_CREATED;
@@ -43,9 +42,9 @@ public class ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest exten
         List<SscsDocument> docs = caseData.getSscsDocument();
 
         assertNull(docs.get(0).getValue().getEvidenceIssued());
-        assertThat(docs.get(1).getValue().getEvidenceIssued(), is("Yes"));
-        assertThat(docs.get(2).getValue().getEvidenceIssued(), is("Yes"));
-        assertThat(docs.get(3).getValue().getEvidenceIssued(), is("Yes"));
+        assertEquals("Yes",docs.get(1).getValue().getEvidenceIssued());
+        assertEquals("Yes",docs.get(2).getValue().getEvidenceIssued());
+        assertEquals("Yes",docs.get(3).getValue().getEvidenceIssued());
     }
 
     private String createTestData() throws IOException {

--- a/src/e2e/resources/appealToProceedCallback.json
+++ b/src/e2e/resources/appealToProceedCallback.json
@@ -24,10 +24,11 @@
     ],
     "security_classification": "PUBLIC",
     "case_data": {
+      "createdInGapsFrom": "readyToList",
       "dwpTimeExtension": [
       ],
       "generatedNino": "JT 12 34 56 D",
-      "interlocReviewState": "appealToProceed",
+      "directionTypeDl": "appealToProceed",
       "hearings": [
         {
           "value": {

--- a/src/e2e/resources/directionIssuedCallback.json
+++ b/src/e2e/resources/directionIssuedCallback.json
@@ -27,7 +27,7 @@
       "dwpTimeExtension": [
       ],
       "generatedNino": "JT 12 34 56 D",
-      "directionType": "appealToProceed",
+      "directionTypeDl": "appealToProceed",
       "hearings": [
         {
           "value": {

--- a/src/e2e/resources/validAppealCreatedCallback.json
+++ b/src/e2e/resources/validAppealCreatedCallback.json
@@ -27,7 +27,7 @@
       "dwpTimeExtension": [
       ],
       "generatedNino": "JT 12 34 56 D",
-      "createdInGapsFrom": "validAppeal",
+      "createdInGapsFrom": "CREATED_IN_GAPS_FROM",
       "hearings": [
         {
           "value": {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/DocmosisPdfGenerationIt.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/DocmosisPdfGenerationIt.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.reform.sscs.service;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
@@ -66,8 +65,8 @@ public class DocmosisPdfGenerationIt {
             .andRespond(withSuccess(FILE_CONTENT, MediaType.APPLICATION_JSON));
 
         byte[] result = pdfGenerationService.generatePdf(DocumentHolder.builder().template(new Template("dl6-template.doc", "dl6")).placeholders(PLACEHOLDERS).build());
-        assertThat(result, is(notNullValue()));
-        assertThat(result, is(equalTo(FILE_CONTENT.getBytes())));
+        assertNotNull(result);
+        assertEquals(FILE_CONTENT.getBytes(), result);
     }
 
     @Test
@@ -81,7 +80,7 @@ public class DocmosisPdfGenerationIt {
             fail("should have thrown bad-request exception");
         } catch (PdfGenerationException e) {
             HttpStatus httpStatus = ((HttpClientErrorException) e.getCause()).getStatusCode();
-            assertThat(httpStatus, is(HttpStatus.BAD_REQUEST));
+            assertEquals(HttpStatus.BAD_REQUEST, httpStatus);
         }
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/DocmosisPdfGenerationIt.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/DocmosisPdfGenerationIt.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.sscs.service;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -65,7 +67,7 @@ public class DocmosisPdfGenerationIt {
 
         byte[] result = pdfGenerationService.generatePdf(DocumentHolder.builder().template(new Template("dl6-template.doc", "dl6")).placeholders(PLACEHOLDERS).build());
         assertNotNull(result);
-        assertEquals(FILE_CONTENT.getBytes(), result);
+        assertThat(result, is(equalTo(FILE_CONTENT.getBytes())));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/DocmosisPdfGenerationIt.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/DocmosisPdfGenerationIt.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.sscs.service;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceIt.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceIt.java
@@ -5,8 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.State.*;
 
@@ -61,9 +59,6 @@ public class RoboticsServiceIt {
 
     @Captor
     private ArgumentCaptor<SscsCaseData> caseDataCaptor;
-
-    @Captor
-    private ArgumentCaptor<String> eventCaptor;
 
     @Before
     public void setup() {
@@ -210,16 +205,6 @@ public class RoboticsServiceIt {
         assertFalse(result.has("hearingArrangements"));
 
         verifyNoMoreInteractions(ccdService);
-    }
-
-    @Test
-    public void givenDwpOfficeIsClosed_thenSaveNewOfficeToCaseWhenRoboticsIsProcessed() {
-        caseDetails.getCaseData().getAppeal().getMrnDetails().setDwpIssuingOffice("1");
-        roboticsService.sendCaseToRobotics(caseDetails);
-
-        verify(ccdService).updateCase(caseDataCaptor.capture(), any(), any(), any(), any(), any());
-
-        assertEquals("DWP PIP (1)", caseDataCaptor.getValue().getAppeal().getMrnDetails().getDwpIssuingOffice());
     }
 
     @Test

--- a/src/integrationTest/resources/validAppealCreatedCallbackWithMrn.json
+++ b/src/integrationTest/resources/validAppealCreatedCallbackWithMrn.json
@@ -2,7 +2,7 @@
   "case_details": {
     "id": 12345656789,
     "jurisdiction": "SSCS",
-    "state": "validAppeal",
+    "state": "CASE_STATE",
     "case_type_id": "Benefit",
     "created_date": [
       2018,
@@ -27,7 +27,7 @@
       "dwpTimeExtension": [
       ],
       "generatedNino": "JT 12 34 56 D",
-      "createdInGapsFrom": "validAppeal",
+      "createdInGapsFrom": "CREATED_IN_GAPS_FROM",
       "hearings": [
         {
           "value": {
@@ -634,5 +634,5 @@
     }
   },
   "case_details_before": null,
-  "event_id": "validAppealCreated"
+    "event_id": "CCD_EVENT_ID"
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/RoboticsService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.sscs.service;
 
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
-import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.CASE_UPDATED;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.State.READY_TO_LIST;
 import static uk.gov.hmcts.reform.sscs.domain.email.EmailAttachment.*;
 
@@ -118,9 +117,6 @@ public class RoboticsService {
 
         if (issuingOfficeChanged || originatingOfficeChanged || presentingOfficeChanged) {
             log.info("Case {} automatically updating DWP office probably due to office closure", sscsCaseData.getCcdCaseId());
-
-            ccdService.updateCase(sscsCaseData, Long.valueOf(sscsCaseData.getCcdCaseId()),
-                CASE_UPDATED.getCcdType(), "Case updated", "Case updated with new DWP office", idamService.getIdamTokens());
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/servicebus/TopicConsumer.java
@@ -26,7 +26,7 @@ public class TopicConsumer {
     private final SscsCaseCallbackDeserializer sscsDeserializer;
 
     public TopicConsumer(@Value("${send-letter.maxRetryAttempts}") Integer maxRetryAttempts,
-                         CallbackDispatcher dispatcher,
+                         CallbackDispatcher<SscsCaseData> dispatcher,
                          SscsCaseCallbackDeserializer sscsDeserializer) {
         this.maxRetryAttempts = maxRetryAttempts;
         //noinspection unchecked

--- a/src/test/java/uk/gov/hmcts/reform/sscs/callback/handlers/IssueFurtherEvidenceHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/callback/handlers/IssueFurtherEvidenceHandlerTest.java
@@ -1,22 +1,13 @@
 package uk.gov.hmcts.reform.sscs.callback.handlers;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscs.callback.handlers.HandlerHelper.buildTestCallbackForGivenData;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.APPELLANT_EVIDENCE;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DWP_EVIDENCE;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.REPRESENTATIVE_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.*;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.ISSUE_FURTHER_EVIDENCE;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.State.INTERLOCUTORY_REVIEW_STATE;
 import static uk.gov.hmcts.reform.sscs.domain.FurtherEvidenceLetterType.APPELLANT_LETTER;
@@ -36,11 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
-import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.ccd.exception.RequiredFieldMissingException;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.exception.IssueFurtherEvidenceException;
@@ -148,8 +135,7 @@ public class IssueFurtherEvidenceHandlerTest {
                 INTERLOCUTORY_REVIEW_STATE, ISSUE_FURTHER_EVIDENCE));
             fail("no exception thrown");
         } catch (IssueFurtherEvidenceException e) {
-            assertThat(e, isA(IssueFurtherEvidenceException.class));
-            assertThat(e.getMessage(), is("Failed sending further evidence for case(1563382899630221)..."));
+            assertEquals("Failed sending further evidence for case(1563382899630221)...", e.getMessage());
         }
 
         verify(ccdService, times(1)).updateCase(captor.capture(), any(Long.class),

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/EmailServiceTest.java
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import uk.gov.hmcts.reform.sscs.domain.email.Email;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/RoboticsServiceTest.java
@@ -341,9 +341,6 @@ public class RoboticsServiceTest {
         roboticsService.sendCaseToRobotics(caseData);
 
         assertThat(caseData.getCaseData().getAppeal().getMrnDetails().getDwpIssuingOffice(), is(newOffice));
-        verify(ccdService).updateCase(caseDataCaptor.capture(), any(), any(), any(), any(), any());
-
-        assertThat(caseDataCaptor.getValue().getAppeal().getMrnDetails().getDwpIssuingOffice(), is(newOffice));
     }
 
     @Test
@@ -362,9 +359,6 @@ public class RoboticsServiceTest {
         roboticsService.sendCaseToRobotics(caseData);
 
         assertThat(caseData.getCaseData().getDwpOriginatingOffice().getValue().getCode(), is(newOffice));
-        verify(ccdService).updateCase(caseDataCaptor.capture(), any(), any(), any(), any(), any());
-
-        assertThat(caseDataCaptor.getValue().getDwpOriginatingOffice().getValue().getCode(), is(newOffice));
     }
 
     @Test
@@ -383,9 +377,6 @@ public class RoboticsServiceTest {
         roboticsService.sendCaseToRobotics(caseData);
 
         assertThat(caseData.getCaseData().getDwpPresentingOffice().getValue().getCode(), is(newOffice));
-        verify(ccdService).updateCase(caseDataCaptor.capture(), any(), any(), any(), any(), any());
-
-        assertThat(caseDataCaptor.getValue().getDwpPresentingOffice().getValue().getCode(), is(newOffice));
     }
 
     @Test
@@ -408,10 +399,5 @@ public class RoboticsServiceTest {
         assertThat(caseData.getCaseData().getAppeal().getMrnDetails().getDwpIssuingOffice(), is(newOffice));
         assertThat(caseData.getCaseData().getDwpOriginatingOffice().getValue().getCode(), is(newOffice));
         assertThat(caseData.getCaseData().getDwpPresentingOffice().getValue().getCode(), is(newOffice));
-        verify(ccdService).updateCase(caseDataCaptor.capture(), any(), any(), any(), any(), any());
-
-        assertThat(caseDataCaptor.getValue().getAppeal().getMrnDetails().getDwpIssuingOffice(), is(newOffice));
-        assertThat(caseData.getCaseData().getDwpOriginatingOffice().getValue().getCode(), is(newOffice));
-        assertThat(caseDataCaptor.getValue().getDwpPresentingOffice().getValue().getCode(), is(newOffice));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/SscsDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/SscsDocumentServiceTest.java
@@ -1,14 +1,9 @@
 package uk.gov.hmcts.reform.sscs.service;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.APPELLANT_EVIDENCE;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.OTHER_DOCUMENT;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.REPRESENTATIVE_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.*;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -52,7 +47,7 @@ public class SscsDocumentServiceTest {
 
         sscsDocumentList.stream()
             .filter(doc -> APPELLANT_EVIDENCE.getValue().equals(doc.getValue().getDocumentType()))
-            .forEach(doc -> assertThat(doc.getValue().getEvidenceIssued(), is("Yes")));
+            .forEach(doc -> assertEquals("Yes", doc.getValue().getEvidenceIssued()));
     }
 
     @Test
@@ -68,10 +63,8 @@ public class SscsDocumentServiceTest {
 
         List<Pdf> actualPdfs = sscsDocumentService.getPdfsForGivenDocTypeNotIssued(createTestData(), documentType);
 
-        assertThat(actualPdfs, hasSize(1));
-        assertThat(actualPdfs, hasItems(
-            new Pdf(new byte[]{'a'}, expectedDocName)
-        ));
+        assertEquals(1, actualPdfs.size());
+        assertEquals(new Pdf(new byte[]{'a'}, expectedDocName), actualPdfs.get(0));
 
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-8482

- Remove a call to CCD to update a closed office. We were hitting CCD twice unnecessarily
- Improve integration tests to cover the digital journey which is now the primary path

