### PR TITLE
Fix flaky nightly tests by generating ninos

### DIFF
--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AbstractFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/AbstractFunctionalTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscs.functional;
 import static io.restassured.RestAssured.baseURI;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.RandomStringUtils;
 import helper.EnvironmentProfileValueSource;
 import io.restassured.RestAssured;
 import java.io.File;
@@ -107,6 +108,10 @@ public abstract class AbstractFunctionalTest {
         String resource = fileName + "Callback.json";
         String file = Objects.requireNonNull(getClass().getClassLoader().getResource(resource)).getFile();
         return FileUtils.readFileToString(new File(file), StandardCharsets.UTF_8.name());
+    }
+
+    public static String getRandomNino() {
+        return RandomStringUtils.random(9, true, true).toUpperCase();
     }
 
     public void simulateCcdCallback(String json) {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/EvidenceShareFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/EvidenceShareFunctionalTest.java
@@ -35,6 +35,7 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
         json = json.replace("MRN_DATE_TO_BE_REPLACED", LocalDate.now().toString());
         json = json.replace("CREATED_IN_GAPS_FROM", State.VALID_APPEAL.getId());
+        json = json.replaceAll("NINO_TO_BE_REPLACED", getRandomNino());
 
         simulateCcdCallback(json);
 
@@ -59,6 +60,7 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
         json = json.replace("MRN_DATE_TO_BE_REPLACED", "");
         json = json.replace("CREATED_IN_GAPS_FROM", State.VALID_APPEAL.getId());
+        json = json.replaceAll("NINO_TO_BE_REPLACED", getRandomNino());
 
         simulateCcdCallback(json);
         SscsCaseDetails caseDetails = findCaseById(ccdCaseId);
@@ -76,6 +78,7 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
         json = json.replace("MRN_DATE_TO_BE_REPLACED", LocalDate.now().minusDays(31).toString());
         json = json.replace("CREATED_IN_GAPS_FROM", State.VALID_APPEAL.getId());
+        json = json.replaceAll("NINO_TO_BE_REPLACED", getRandomNino());
 
         simulateCcdCallback(json);
         SscsCaseDetails caseDetails = findCaseById(ccdCaseId);
@@ -99,6 +102,7 @@ public class EvidenceShareFunctionalTest extends AbstractFunctionalTest {
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
         json = json.replace("MRN_DATE_TO_BE_REPLACED", LocalDate.now().toString());
         json = json.replace("CREATED_IN_GAPS_FROM", State.READY_TO_LIST.getId());
+        json = json.replaceAll("NINO_TO_BE_REPLACED", getRandomNino());
 
         simulateCcdCallback(json);
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/IssueFurtherEvidenceHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/IssueFurtherEvidenceHandlerFunctionalTest.java
@@ -113,6 +113,8 @@ public class IssueFurtherEvidenceHandlerFunctionalTest extends AbstractFunctiona
         json = json.replace("CASE_ID_TO_BE_REPLACED", ccdCaseId);
         json = json.replace("EVIDENCE_DOCUMENT_URL_PLACEHOLDER", docUrl);
         json = json.replace("CREATED_IN_GAPS_FROM", State.READY_TO_LIST.getId());
+        json = json.replaceAll("NINO_TO_BE_REPLACED", getRandomNino());
+
         return json.replace("EVIDENCE_DOCUMENT_BINARY_URL_PLACEHOLDER", docUrl + "/binary");
     }
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest.java
@@ -58,6 +58,7 @@ public class ReissueAppellantAppointeeFurtherEvidenceHandlerFunctionalTest exten
         json = json.replaceAll("CASE_ID_TO_BE_REPLACED", ccdCaseId);
         json = json.replaceAll("EVIDENCE_DOCUMENT_URL_PLACEHOLDER", docUrl);
         json = json.replace("CREATED_IN_GAPS_FROM", State.READY_TO_LIST.getId());
+        json = json.replaceAll("NINO_TO_BE_REPLACED", getRandomNino());
         return json.replaceAll("EVIDENCE_DOCUMENT_BINARY_URL_PLACEHOLDER", docUrl + "/binary");
     }
 

--- a/src/e2e/resources/issueFurtherEvidenceCallback.json
+++ b/src/e2e/resources/issueFurtherEvidenceCallback.json
@@ -25,7 +25,7 @@
     "security_classification": "PUBLIC",
     "case_data": {
       "evidencePresent": "No",
-      "generatedNino": "JJ123457A",
+      "generatedNino": "NINO_TO_BE_REPLACED",
       "subscriptions": {
         "appellantSubscription": {
           "tya": null,
@@ -125,7 +125,7 @@
           },
           "identity": {
             "dob": "1979-12-09",
-            "nino": "JJ123457A"
+            "nino": "NINO_TO_BE_REPLACED"
           },
           "appointee": {
             "name": {
@@ -147,7 +147,7 @@
             },
             "identity": {
               "dob": "1976-11-11",
-              "nino": "JJ123457A"
+              "nino": "NINO_TO_BE_REPLACED"
             }
           },
           "isAppointee": "No",

--- a/src/e2e/resources/issueFurtherEvidenceExistingReasonableAdjustmentCallback.json
+++ b/src/e2e/resources/issueFurtherEvidenceExistingReasonableAdjustmentCallback.json
@@ -53,7 +53,7 @@
         "appointee": null
       },
       "evidencePresent": "No",
-      "generatedNino": "JJ123457A",
+      "generatedNino": "NINO_TO_BE_REPLACED",
       "subscriptions": {
         "appellantSubscription": {
           "tya": null,
@@ -153,7 +153,7 @@
           },
           "identity": {
             "dob": "1979-12-09",
-            "nino": "JJ123457A"
+            "nino": "NINO_TO_BE_REPLACED"
           },
           "appointee": {
             "name": {
@@ -175,7 +175,7 @@
             },
             "identity": {
               "dob": "1976-11-11",
-              "nino": "JJ123457A"
+              "nino": "NINO_TO_BE_REPLACED"
             }
           },
           "isAppointee": "No",

--- a/src/e2e/resources/issueFurtherEvidenceReasonableAdjustmentCallback.json
+++ b/src/e2e/resources/issueFurtherEvidenceReasonableAdjustmentCallback.json
@@ -31,7 +31,7 @@
         }
       },
       "evidencePresent": "No",
-      "generatedNino": "JJ123457A",
+      "generatedNino": "NINO_TO_BE_REPLACED",
       "subscriptions": {
         "appellantSubscription": {
           "tya": null,
@@ -131,7 +131,7 @@
           },
           "identity": {
             "dob": "1979-12-09",
-            "nino": "JJ123457A"
+            "nino": "NINO_TO_BE_REPLACED"
           },
           "appointee": {
             "name": {
@@ -153,7 +153,7 @@
             },
             "identity": {
               "dob": "1976-11-11",
-              "nino": "JJ123457A"
+              "nino": "NINO_TO_BE_REPLACED"
             }
           },
           "isAppointee": "No",

--- a/src/e2e/resources/reissueFurtherEvidenceCallback.json
+++ b/src/e2e/resources/reissueFurtherEvidenceCallback.json
@@ -25,7 +25,7 @@
     "security_classification": "PUBLIC",
     "case_data": {
       "evidencePresent": "No",
-      "generatedNino": "JJ123457A",
+      "generatedNino": "NINO_TO_BE_REPLACED",
       "subscriptions": {
         "appellantSubscription": {
           "tya": null,
@@ -125,7 +125,7 @@
           },
           "identity": {
             "dob": "1979-12-09",
-            "nino": "JJ123457A"
+            "nino": "NINO_TO_BE_REPLACED"
           },
           "appointee": {
             "name": {
@@ -147,7 +147,7 @@
             },
             "identity": {
               "dob": "1976-11-11",
-              "nino": "JJ123457A"
+              "nino": "NINO_TO_BE_REPLACED"
             }
           },
           "isAppointee": "No",

--- a/src/e2e/resources/validAppealCreatedCallback.json
+++ b/src/e2e/resources/validAppealCreatedCallback.json
@@ -26,7 +26,7 @@
     "case_data": {
       "dwpTimeExtension": [
       ],
-      "generatedNino": "JT 12 34 56 D",
+      "generatedNino": "NINO_TO_BE_REPLACED",
       "createdInGapsFrom": "CREATED_IN_GAPS_FROM",
       "hearings": [
         {
@@ -112,7 +112,7 @@
           },
           "identity": {
             "dob": "1900-01-01",
-            "nino": "JT 12 34 56 D"
+            "nino": "NINO_TO_BE_REPLACED"
           },
           "isAppointee": null
         },


### PR DESCRIPTION
Fix flaky nightly tests by generating NI numbers

The nightly tests fail because it tries to run the 'associate case' event on cases with matching ninos, but those cases are really old and have some stale data.

The old cases have been updated, but the tests are still failing So this PR changes the tests to update the nino so that it will not try to associate the case.