### PR TITLE
SSCS Post hearings-SOR-Name and Address missing on Cover Letter

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/placeholders/SorPlaceholderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/placeholders/SorPlaceholderService.java
@@ -45,7 +45,10 @@ public class SorPlaceholderService {
         placeholders.put(HMCTS2, HMCTS_IMG);
         placeholders.put(APPEAL_REF, caseData.getCcdCaseId());
         placeholders.put(ENTITY_TYPE, entityType);
-        placeholders.put(APPELLANT_NAME, caseData.getAppeal().getAppellant().getName().getFullNameNoTitle());
+        placeholders.put(NAME, caseData.getAppeal().getAppellant().getName().getFullNameNoTitle());
+        placeholders.put(LETTER_ADDRESS_LINE_1, caseData.getAppeal().getAppellant().getAddress().getLine1());
+        placeholders.put(LETTER_ADDRESS_LINE_2, caseData.getAppeal().getAppellant().getAddress().getLine2());
+        placeholders.put(LETTER_ADDRESS_POSTCODE, caseData.getAppeal().getAppellant().getAddress().getPostcode());
 
         Hearing latestHearing = caseData.getLatestHearing();
         if (!isNull(latestHearing) && !isNull(latestHearing.getValue())) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/placeholders/SorPlaceholderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/placeholders/SorPlaceholderServiceTest.java
@@ -46,4 +46,14 @@ public class SorPlaceholderServiceTest {
         assertEquals(caseData.getAppeal().getAppellant().getName().getFullNameNoTitle(), placeholders.get(PlaceholderConstants.NAME));
         assertEquals(Appellant.class.getSimpleName(), placeholders.get(ENTITY_TYPE));
     }
+
+    @Test
+    void addressTest() {
+        var addressPlaceholders = sorPlaceholderService.populatePlaceholders(caseData, FurtherEvidenceLetterType.APPELLANT_LETTER,
+            Appellant.class.getSimpleName(), null);
+
+        assertEquals(caseData.getAppeal().getAppellant().getAddress().getLine1(), addressPlaceholders.get(PlaceholderConstants.LETTER_ADDRESS_LINE_1));
+        assertEquals(caseData.getAppeal().getAppellant().getAddress().getLine2(), addressPlaceholders.get(PlaceholderConstants.LETTER_ADDRESS_LINE_2));
+        assertEquals(caseData.getAppeal().getAppellant().getAddress().getPostcode(), addressPlaceholders.get(PlaceholderConstants.LETTER_ADDRESS_POSTCODE));
+    }
 }


### PR DESCRIPTION
### Change description ###
Include Name and Address into SOR cover letter
