### PR TITLE
SSCSCI - Revert send-letter-client upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -316,7 +316,7 @@ dependencies {
   implementation group: 'org.apache.qpid', name: 'qpid-jms-client', version: '1.8.0'
 
   implementation group: 'com.github.hmcts', name: 'cmc-pdf-service-client', version: '7.0.1'
-  implementation group: 'com.github.hmcts', name: 'send-letter-client', version: '3.0.23'
+  implementation group: 'com.github.hmcts', name: 'send-letter-client', version: '3.0.16'
   // Remove this dependency once the secure doc-store is in use
   implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.1'
 


### PR DESCRIPTION
### Change description ###
Revert send-letter-client from 3.0.23 to 3.0.16 due to failing master build